### PR TITLE
Add ratio charts

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -158,22 +158,23 @@ function setUpModels(db) {
 
     models.Pod.projectCharts = function (projectName, callback) {
       var query =
-        "SELECT UNIX_TIMESTAMP(date) AS timestamp,\
+        "SELECT timestamp, nodes, users, active_users_halfyear, active_users_monthly, local_posts, local_comments,\
+        users / nodes AS users_per_node,\
+        active_users_monthly / users AS active_users_ratio,\
+        local_posts / users AS posts_per_user,\
+        local_comments / users AS comments_per_user \
+        FROM (SELECT UNIX_TIMESTAMP(date) AS timestamp,\
          COUNT(pod_id) AS nodes,\
          SUM(total_users) AS users,\
          SUM(active_users_halfyear) AS active_users_halfyear,\
          SUM(active_users_monthly) AS active_users_monthly,\
          SUM(local_posts) AS local_posts,\
-         SUM(local_comments) AS local_comments,\
-         users / nodes AS users_per_node,\
-         active_users_monthly / users AS active_users_ratio,\
-         local_posts / users AS posts_per_user,\
-         local_comments / users AS comments_per_user \
+         SUM(local_comments) AS local_comments \
          FROM stats s";
       if (projectName != undefined && projectName != "") {
         query += ", pods p WHERE s.pod_id = p.id AND p.network = '" + projectName + "'";
       }
-      query += " GROUP BY date";
+      query += " GROUP BY date) temp";
       execQueryWithCallback(query, callback);
     };
     models.Pod.allForList = function (callback) {

--- a/src/database.js
+++ b/src/database.js
@@ -159,10 +159,10 @@ function setUpModels(db) {
     models.Pod.projectCharts = function (projectName, callback) {
       var query =
         "SELECT timestamp, nodes, users, active_users_halfyear, active_users_monthly, local_posts, local_comments,\
-        users / nodes AS users_per_node,\
-        active_users_monthly / users AS active_users_ratio,\
-        local_posts / users AS posts_per_user,\
-        local_comments / users AS comments_per_user \
+        users / NULLIF(nodes, 0) AS users_per_node,\
+        active_users_monthly / NULLIF(users, 0) AS active_users_ratio,\
+        local_posts / NULLIF(users, 0) AS posts_per_user,\
+        local_comments / NULLIF(users, 0) AS comments_per_user \
         FROM (SELECT UNIX_TIMESTAMP(date) AS timestamp,\
          COUNT(pod_id) AS nodes,\
          SUM(total_users) AS users,\

--- a/src/database.js
+++ b/src/database.js
@@ -13,15 +13,17 @@ var orm = require('orm'),
     utils = require('./utils');
 
 function setUpModels(db) {
-  function execQueryWithCallback(query, callback) {
-    db.driver.execQuery(query, [],
-    function(err, data) {
-        if (err) {
-            console.log(err);
-        }
-        callback(data);
-    });
-  }
+
+    function execQueryWithCallback(query, callback) {
+      db.driver.execQuery(query, [],
+      function(err, data) {
+          if (err) {
+              console.log(err);
+          }
+          callback(data);
+      });
+    }
+
     // set up models
     models.Pod = db.define('pods', {
         name: { type: "text", size: 300 },
@@ -162,7 +164,11 @@ function setUpModels(db) {
          SUM(active_users_halfyear) AS active_users_halfyear,\
          SUM(active_users_monthly) AS active_users_monthly,\
          SUM(local_posts) AS local_posts,\
-         SUM(local_comments) AS local_comments\
+         SUM(local_comments) AS local_comments,\
+         users / nodes AS users_per_node,\
+         active_users_monthly / users AS active_users_ratio,\
+         local_posts / users AS posts_per_user,\
+         local_comments / users AS comments_per_user \
          FROM stats s";
       if (projectName != undefined && projectName != "") {
         query += ", pods p WHERE s.pod_id = p.id AND p.network = '" + projectName + "'";

--- a/src/views/charts/_stats_with_selectors.njk
+++ b/src/views/charts/_stats_with_selectors.njk
@@ -14,6 +14,10 @@
       <div id="monthly-chart" class="btn-medium">Last month users</div>
       <div id="posts-chart" class="btn-medium">Posts</div>
       <div id="comments-chart" class="btn-medium">Comments</div>
+      <div id="users-per-node-chart" class="btn-medium">Users per node</div>
+      <div id="active-users-ratio-chart" class="btn-medium">Active users ratio</div>
+      <div id="posts-per-user-chart" class="btn-medium">Posts per user</div>
+      <div id="comments-per-user-chart" class="btn-medium">Comments per user</div>
     </div>
   </div>
 </section>
@@ -38,6 +42,10 @@
   var monthlyUsersData = prepareData(data, "active_users_monthly");
   var postsData = prepareData(data, "local_posts");
   var commentsData = prepareData(data, "local_comments");
+  var usersPerNodeData = prepareData(data, "users_per_node");
+  var activeUsersRatioData = prepareData(data, "active_users_ratio");
+  var postsPerUserData = prepareData(data, "posts_per_user");
+  var commentsPerUserData = prepareData(data, "comments_per_user");
   var chart = initChart(document.getElementById("chart"), "Nodes", nodesData);
 
   document.getElementById('nodes-chart').addEventListener('click', function() {
@@ -57,5 +65,17 @@
   });
   document.getElementById('comments-chart').addEventListener('click', function() {
     refreshChart(chart, "Local comments", commentsData);
+  });
+  document.getElementById('users-per-node-chart').addEventListener('click', function() {
+    refreshChart(chart, "Users per node", commentsData);
+  });
+  document.getElementById('active-users-ratio-chart').addEventListener('click', function() {
+    refreshChart(chart, "Active users ratio", commentsData);
+  });
+  document.getElementById('posts-per-user-chart').addEventListener('click', function() {
+    refreshChart(chart, "Posts per user comments", commentsData);
+  });
+  document.getElementById('comments-per-user-chart').addEventListener('click', function() {
+    refreshChart(chart, "Comments per users", commentsData);
   });
 </script>

--- a/src/views/charts/_stats_with_selectors.njk
+++ b/src/views/charts/_stats_with_selectors.njk
@@ -67,15 +67,15 @@
     refreshChart(chart, "Local comments", commentsData);
   });
   document.getElementById('users-per-node-chart').addEventListener('click', function() {
-    refreshChart(chart, "Users per node", commentsData);
+    refreshChart(chart, "Users per node", usersPerNodeData);
   });
   document.getElementById('active-users-ratio-chart').addEventListener('click', function() {
-    refreshChart(chart, "Active users ratio", commentsData);
+    refreshChart(chart, "Active users ratio", activeUsersRatioData);
   });
   document.getElementById('posts-per-user-chart').addEventListener('click', function() {
-    refreshChart(chart, "Posts per user comments", commentsData);
+    refreshChart(chart, "Posts per user", postsPerUserData);
   });
   document.getElementById('comments-per-user-chart').addEventListener('click', function() {
-    refreshChart(chart, "Comments per users", commentsData);
+    refreshChart(chart, "Comments per user", commentsPerUserData);
   });
 </script>


### PR DESCRIPTION
Add users per node, active users ratio, posts per user and comments per user charts to _stats_with_selectors. So we start to get power out of numbers and have other interesting calculated indicators. Base on #71 so please merge the other one first.