### PR TITLE
Support fetching NodeInfo2 documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "license": "AGPLv3",
   "dependencies": {
-    "mysql": "2.0.0-rc1",
+    "mysql": "2.13.0",
     "express": "3.2.4",
     "express-validator": "1.0.0",
     "geoip-lite": "~1.1.8",
@@ -14,6 +14,6 @@
     "nodemailer": "1.3.2",
     "nodemailer-smtp-transport": "1.0.2",
     "nunjucks": "2.5.2",
-    "orm": "2.1.3"
+    "orm": "3.2.3"
   }
 }


### PR DESCRIPTION
On unknown hosts, always try NodeInfo2 first. On known hosts, use the
highest known supported one.

Also bump mysql and node-orm dependencies.