### PR TITLE
Don't call hosts which have failed over 30 times

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -256,8 +256,10 @@ network.callAllPods = function() {
             console.log(err);
         }
         for (i = 0; i < pods.length; i++) {
-            podhost = pods[i].host;
-            setTimeout(network.callPod, Math.floor(Math.random() * 10000) + 1, podhost);
+            if (pods[i].failures < 30) {
+                podhost = pods[i].host;
+                setTimeout(network.callPod, Math.floor(Math.random() * 10000) + 1, podhost);
+            }
         }
         setTimeout(db.GlobalStat.logStats, 300000);
     });


### PR DESCRIPTION
They can always re-register to force a call if they come up one day. All the dead hosts are starting to cause a lot of weight when doing daily checks.