### PR TITLE
Add 'New users, posts and comments per day' charts

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -28,7 +28,13 @@ function setUpModels(db) {
           users / NULLIF(nodes, 0) AS users_per_node,\
           active_users_monthly / NULLIF(users, 0) AS active_users_ratio,\
           local_posts / NULLIF(users, 0) AS posts_per_user,\
-          local_comments / NULLIF(users, 0) AS comments_per_user \
+          local_comments / NULLIF(users, 0) AS comments_per_user,\
+          users - NULLIF(@preRowUsers, 0) AS new_users,\
+          @preRowUsers := users AS dummyUsers,\
+          local_posts - NULLIF(@preRowPosts, 0) AS new_posts,\
+          @preRowPosts := local_posts AS dummyPosts,\
+          local_comments - NULLIF(@preRowComments, 0) AS new_comments,\
+          @preRowComments := local_comments AS dummyComments\
           FROM (SELECT UNIX_TIMESTAMP(date) AS timestamp,\
            COUNT(pod_id) AS nodes,\
            SUM(total_users) AS users,\

--- a/src/views/charts/_stats_with_selectors.njk
+++ b/src/views/charts/_stats_with_selectors.njk
@@ -23,6 +23,9 @@
             <div data-name="active_users_ratio" class="btn-medium">Active users ratio</div>
             <div data-name="posts_per_user" class="btn-medium">Posts per user</div>
             <div data-name="comments_per_user" class="btn-medium">Comments per user</div>
+            <div data-name="new_users" class="btn-medium">New users</div>
+            <div data-name="new_posts" class="btn-medium">New posts</div>
+            <div data-name="new_comments" class="btn-medium">New comments</div>
         </div>
     </div>
 </section>


### PR DESCRIPTION
These charts allow us to follow when the network has a big activity (or when nothing is happening).
With these changes, cleaning the peaks is even more important ;)
Also it makes #16 more important, the charts are difficult to read at the moment.