### PR TITLE
Raise 404 on /node/<node> route if node not found

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -66,6 +66,10 @@ routes.renderNetwork = function (network, res, db) {
 routes.renderNode = function (req, res, db) {
     var nodeHost = req.params.host;
     db.Pod.nodeInfo(nodeHost, function (nodeInfo) {
+        if (!nodeInfo.length) {
+            res.send(404);
+            return
+        }
         db.Pod.nodeCharts(nodeHost, function (chartData) {
             res.render("node.njk", {
                 node: utils.formatNodeInfo(nodeInfo[0]),


### PR DESCRIPTION
Previously the site would crash due to the node not being in the database but we still tried to render it.